### PR TITLE
Check and update backend database connection

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -7,7 +7,7 @@ dotenv.config();
 
 // First, let's try to connect as root to set up everything
 const rootDb = mysql.createConnection({
-  host: 'localhost',  // Explicitly use localhost
+  host: '192.168.99.252',  // Updated to Windows host IP
   user: 'root',
   password: 'root',   // Explicit password
   database: 'lims_db'
@@ -17,7 +17,7 @@ const rootDb = mysql.createConnection({
 
 // Now connect as lims_user
 const db = mysql.createConnection({
-  host: 'localhost',  // Explicitly use localhost
+  host: '192.168.99.252',  // Updated to Windows host IP
   user: 'lims_user',
   password: 'root',   // Explicit password
   database: 'lims_db'
@@ -30,7 +30,7 @@ rootDb.connect((rootErr) => {
     
     // If root connection fails, try with lims_user
     const db = mysql.createConnection({
-      host: process.env.DB_HOST || 'localhost',
+      host: process.env.DB_HOST || '192.168.99.252',
       user: 'lims_user',
       password: process.env.DB_PASSWORD || 'root', // Use consistent password
       database: process.env.DB_NAME || 'lims_db'
@@ -95,7 +95,7 @@ rootDb.connect((rootErr) => {
               
               // Now connect as lims_user
               const db = mysql.createConnection({
-                host: process.env.DB_HOST || 'localhost',
+                host: process.env.DB_HOST || '192.168.99.252',
                 user: 'lims_user',
                 password: process.env.DB_PASSWORD || 'root', // Consistent password
                 database: process.env.DB_NAME || 'lims_db'

--- a/backend/routes/sampleRegistration.js
+++ b/backend/routes/sampleRegistration.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 const mysql = require('mysql2');
 const db = mysql.createConnection({
-  host: process.env.DB_HOST || 'localhost',
+  host: process.env.DB_HOST || '192.168.99.252',
   user: process.env.DB_USER || 'root',
   password: process.env.DB_PASSWORD || 'root',
   database: process.env.DB_NAME || 'lims_db'

--- a/backend/test.js
+++ b/backend/test.js
@@ -1,7 +1,7 @@
 const mysql = require('mysql2');
 
 const connection = mysql.createConnection({
-  host: 'localhost',
+  host: '192.168.99.252',
   user: 'root',
   password: 'root',
   database: 'lims_db'


### PR DESCRIPTION
Update MySQL connection host to `192.168.99.252` to connect the backend to a Windows-hosted MySQL server.

The backend environment (Linux/WSL) was attempting to connect to `localhost`, which refers to itself, while the MySQL server was running on the Windows host. Updating the host IP allows the backend to correctly locate and connect to the MySQL instance.